### PR TITLE
Bug Fix : drawFancyString(5 args)

### DIFF
--- a/src/main/scala/hevs/graphics/FunGraphics.scala
+++ b/src/main/scala/hevs/graphics/FunGraphics.scala
@@ -354,7 +354,7 @@ class FunGraphics(val width: Int, val height: Int, val xoffset: Int, val yoffset
   override def drawFancyString(posX: Int, posY: Int, str: String, color: Color, size: Int): Unit = {
     val font: Font = new Font("Georgia", Font.BOLD, size)
     drawString(posX+2, posY+2, str, font, color = Color.GRAY)
-    drawString(posX, posY, str, fontSize = size, color = color)
+    drawString(posX, posY, str, font, color = color)
   }
 
   override def drawFancyString(posX: Int,


### PR DESCRIPTION
Bug de la fonction drawFancyString(5 args). La style de l'écriture de l'ombre n'est pas la même que celle du texte devant.

Changement : "fontsize=size" remplacé par "font".