### PR TITLE
fix: drawFillRect wasn't filling rect

### DIFF
--- a/src/main/scala/hevs/graphics/FunGraphics.scala
+++ b/src/main/scala/hevs/graphics/FunGraphics.scala
@@ -270,7 +270,7 @@ class FunGraphics(val width: Int, val height: Int, val xoffset: Int, val yoffset
 	}
 
 	override def drawFillRect(rect: Rectangle): Unit = {
-		g2d.drawRect(rect.getX.toInt, rect.y, rect.getWidth.toInt, rect.getHeight.toInt)
+		g2d.fillRect(rect.getX.toInt, rect.y, rect.getWidth.toInt, rect.getHeight.toInt)
 	}
 
 	override def drawCircle(posX: Int, posY: Int, f: Int): Unit = {


### PR DESCRIPTION
The method `drawFillRect(rect: Rectangle)` wasn't drawing a filled rectangle, but only the outlines.

Before the fix:
<img width="550" height="587" alt="Capture d’écran du 2026-01-07 21-25-50" src="https://github.com/user-attachments/assets/945f5aa1-1fc3-499d-8a94-a90b3f32f4ec" />


After the fix:
<img width="550" height="587" alt="Capture d’écran du 2026-01-07 21-25-34" src="https://github.com/user-attachments/assets/b3540cfe-0d19-4b3d-801e-38956a458e06" />
